### PR TITLE
docs: add community health files and improve README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and this changelog.
+- Expanded README with development setup, troubleshooting, and clearer API key instructions.
+
+## [1.0.0] - 2024-11-18
+
+### Added
+- Initial release of Echo — a macOS prototype that uses the Accessibility API and OpenAI GPT-4o to interact with the frontmost application's text editor.
+- Real-time frontmost application detection.
+- Chat-style UI built with SwiftUI embedded in AppKit.
+- Xcode 15 / macOS 14 support.
+- CodeQL security scanning workflow.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct.
+
+We are committed to providing a welcoming and respectful environment for everyone. All contributors, maintainers, and participants are expected to follow the standards outlined in the Covenant when interacting in any project space (issues, pull requests, discussions, etc.).
+
+## Reporting
+
+To report a concern, please contact the maintainers at [research@macpaw.com](mailto:research@macpaw.com). All reports will be reviewed and investigated promptly and fairly.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing these standards and may take appropriate corrective action in response to any behavior they deem inappropriate.
+
+The full text, including reporting guidelines and enforcement, is available at:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Echo
+
+Thank you for your interest in contributing to Echo! This document outlines how to participate in the project.
+
+## Reporting Issues
+
+- **Bug reports**: Use the [Bug Report](.github/ISSUE_TEMPLATE/bug_report.yml) template. Include your macOS version, Xcode version, and clear reproduction steps.
+- **Feature requests**: Use the [Feature Request](.github/ISSUE_TEMPLATE/feature_request.yml) template.
+- Before opening a new issue, please search existing ones to avoid duplicates.
+
+## Pull Requests
+
+1. **Fork** the repository and create your branch from `develop`:
+   ```bash
+   git checkout -b feat/my-feature origin/develop
+   ```
+
+2. **Branch naming conventions**:
+   - `feat/` — new features
+   - `fix/` — bug fixes
+   - `chore/` — tooling, CI, dependencies
+   - `docs/` — documentation only
+
+3. **Build and test** locally before submitting:
+   ```bash
+   open Echo.xcodeproj
+   # Cmd+B to build, Cmd+R to run
+   ```
+
+4. **Code style**: The project uses [SwiftLint](https://github.com/realm/SwiftLint). Run `swiftlint lint` from the project root before committing. CI will fail if there are violations.
+
+5. **Keep PRs focused**: One logical change per PR. If you find an unrelated issue, open a separate PR or issue for it.
+
+6. Submit your PR against the `develop` branch and fill in the pull request template.
+
+## Development Setup
+
+See the [Development Setup](README.md#development-setup) section in the README for build instructions and required environment variables.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold these standards.

--- a/README.md
+++ b/README.md
@@ -4,28 +4,29 @@
 
 **Echo** is a macOS application that demonstrates how to interact with macOS applications using Accessibility and [OpenAI](https://openai.com) APIs. It allows users to send prompts to the frontmost application and receive responses, showcasing a functional chat-like interface.
 
-<img width="1800" alt="Screenshot 2024-11-18 at 2 58 45 PM" src="https://github.com/user-attachments/assets/b7d2a457-d4c6-430b-8fae-c3364ea4c7af">
+<img width="1800" alt="Screenshot 2024-11-18 at 2 58 45 PM" src="https://github.com/user-attachments/assets/b7d2a457-d4c6-430b-8fae-c3364ea4c7af">
 
 ## Features
 
 - **Real-Time Frontmost Application Detection**: Automatically detects the currently active macOS application.
-- **User Prompts**: Send prompts to interact with text area of the detected application.
-- **Chat View Interface**: Displays interactions in a chat-like interface
+- **User Prompts**: Send prompts to interact with the text area of the detected application.
+- **Chat View Interface**: Displays interactions in a chat-like interface.
 
-> [!WARNING]  
-> Project Echo is an experimental prototype that demonstrates an approach, use in on your own risk
+> [!WARNING]
+> Project Echo is an experimental prototype that demonstrates an approach. Use it at your own risk.
 
 ## Requirements
 
 - macOS 14.0 or later
 - Xcode 15.0 or later
+- An [OpenAI API key](https://platform.openai.com/api-keys)
 
-## Installation
+## Development Setup
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/username/Echo.git
-   cd Echo
+   git clone https://github.com/MacPaw/project-echo.git
+   cd project-echo
    ```
 
 2. Open the project in Xcode:
@@ -33,52 +34,77 @@
    open Echo.xcodeproj
    ```
 
-3. Build and run the project:
+3. Set the `OPEN_AI` environment variable in your Xcode scheme:
+   - In Xcode, go to **Product > Scheme > Edit Scheme…**
+   - Select **Run** in the left sidebar, then open the **Arguments** tab.
+   - Under **Environment Variables**, click **+** and add:
+     - Name: `OPEN_AI`
+     - Value: your OpenAI API key
+
+   <img width="945" alt="Xcode scheme environment variable setup" src="https://github.com/user-attachments/assets/ab34b050-2401-4ce1-be4c-3452470d95fa">
+
+   Alternatively, when launching from the terminal:
+   ```bash
+   OPEN_AI=your_api_key_here open Echo.app
+   ```
+
+4. Build and run the project:
    - Select your target device (Mac).
    - Press **Cmd + R** or click the Run button in Xcode.
 
 ## Usage
 
 1. Launch **Echo** on macOS.
-2. Activate/launch 3rd party application
-3. Type your prompt into the text field
+2. Activate or launch a 3rd party application (e.g. Xcode, TextMate, Safari).
+3. Type your prompt into the text field (e.g. "Convert to Objective-C", "Fix typos").
 4. Click the **Send** button to interact with the frontmost application.
-5. View the response in the chat interface.
+5. View the response in the chat interface — the focused text area will be updated automatically.
 
-Note: You should add OpenAI API key to environment variables.
-<img width="945" alt="Screenshot 2024-11-18 at 2 43 48 PM" src="https://github.com/user-attachments/assets/ab34b050-2401-4ce1-be4c-3452470d95fa">
+## Accessibility Permissions
+
+Echo requires macOS Accessibility permissions and will prompt you automatically on first launch. To grant them manually:
+
+1. Open **System Settings** > **Privacy & Security** > **Accessibility**.
+2. Click the lock to make changes and authenticate.
+3. Add **Echo** to the list of allowed applications.
+
+## Troubleshooting
+
+**App crashes immediately on launch**
+The `OPEN_AI` environment variable is not set. Follow the [Development Setup](#development-setup) steps above to configure it in your Xcode scheme.
+
+**Echo does not detect the frontmost window / "No editor" in the log**
+The target application must expose an `AXTextArea` element. This works in most native text editors (Xcode, TextMate, BBEdit). Browser address bars and some web text areas may not be accessible via the Accessibility API.
+
+**Accessibility permission is denied**
+Open **System Settings > Privacy & Security > Accessibility** and verify that Echo is listed and toggled on. Re-building from Xcode may require re-granting the permission.
+
+**OpenAI API errors**
+Verify your API key is valid and has GPT-4o access. Check your [OpenAI usage dashboard](https://platform.openai.com/usage) for quota issues.
 
 ## Code Overview
 
 ### Key Components
 
-- **`ViewController`**: 
-  - Manages the main app logic, including UI setup, handling user prompts, and interacting with applications.
-  
-- **`MessagesStore`**: 
-  - Stores and manages messages displayed in the chat interface.
+- **`ViewController`**:
+  Manages the main app logic, including UI setup, handling user prompts, and interacting with applications.
 
-- **`Agent`**: 
-  - Processes user prompts and generates responses based on the content of the frontmost application.
+- **`MessagesStore`**:
+  Stores and manages messages displayed in the chat interface.
 
-- **`FrontmostApplication`**: 
-  - Observes and detects the currently active macOS application.
+- **`Agent`**:
+  Processes user prompts and generates responses based on the content of the frontmost application.
 
-- **`AccessbilableApplication`**: 
-  - Provides Accessibility API integration to fetch and update content in the frontmost application.
+- **`FrontmostApplication`**:
+  Observes and detects the currently active macOS application.
+
+- **`AccessbilableApplication`**:
+  Provides Accessibility API integration to fetch and update content in the frontmost application.
 
 ### View Hierarchy
 
 - **Chat Interface**:
-  - Built using `SwiftUI` and embedded into `NSViewController` via `NSHostingController`.
-
-## Accessibility Permissions
-
-This app requires and asks automatically macOS Accessibility permissions to function correctly. Follow these steps to grant permissions:
-
-1. Open **System Preferences** > **Privacy & Security** > **Accessibility**.
-2. Click the lock to make changes and authenticate.
-3. Add **Echo** to the list of allowed applications.
+  Built using `SwiftUI` and embedded into `NSViewController` via `NSHostingController`.
 
 ## Example Screenshots
 
@@ -94,6 +120,10 @@ This app requires and asks automatically macOS Accessibility permissions to func
 ## Demo Video
 
 [![Youtube Demo Video](https://img.youtube.com/vi/RmiFfuKhAJQ/0.jpg)](https://www.youtube.com/watch?v=RmiFfuKhAJQ)
+
+## Contributing
+
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 ## License
 


### PR DESCRIPTION
## Summary

Polishes the project for an external audience by adding the standard community health files and tightening the README.

- Replace the placeholder clone URL (`https://github.com/username/Echo.git`) with the real `MacPaw/project-echo` URL
- Add an explicit "Set the OPEN_AI environment variable in your Xcode scheme" walkthrough
- Add a Troubleshooting section covering the most common setup issues (missing API key, missing AXTextArea, accessibility permission, OpenAI quota)
- New `CONTRIBUTING.md` — branch naming, build steps, PR checklist
- New `CODE_OF_CONDUCT.md` — adopts Contributor Covenant v2.1
- New `CHANGELOG.md` — Keep a Changelog format with 1.0.0 baseline + Unreleased section

## Type of Change

- [x] Documentation

## Test plan

- [ ] Visual review of the rendered README on GitHub
- [ ] Verify all internal links resolve (CONTRIBUTING, CODE_OF_CONDUCT, LICENSE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)