### PR TITLE
chore: add GitHub issue/PR templates, CODEOWNERS, env gitignore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for all files
+* @krivoblotsky

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report a problem with Echo
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the problem.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps that reliably reproduce the issue.
+      placeholder: |
+        1. Launch Echo
+        2. Open Xcode
+        3. Type prompt "..."
+        4. Click Send
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+  - type: input
+    id: macos-version
+    attributes:
+      label: macOS Version
+      placeholder: "14.5"
+    validations:
+      required: true
+  - type: input
+    id: xcode-version
+    attributes:
+      label: Xcode Version
+      placeholder: "16.1"
+    validations:
+      required: true
+  - type: input
+    id: target-app
+    attributes:
+      label: Target Application (the app Echo was interacting with)
+      placeholder: "Xcode 16.1, TextMate 2.0, Safari 18.0"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console Logs
+      description: Any relevant output from Console.app or Xcode (please redact API keys).
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+        - label: I have set the `OPEN_AI` environment variable correctly.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem are you trying to solve? Why does it matter?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like Echo to solve this?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches you've thought about.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Screenshots, mockups, related issues, links, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- Briefly describe what this PR changes and why. -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Related Issue
+
+<!-- Link any related issues, e.g. "Closes #123" -->
+
+## Testing
+
+- [ ] Built locally with Xcode
+- [ ] Ran the app and verified the change manually
+- [ ] SwiftLint passes (`swiftlint lint`)
+
+## Screenshots / Recording
+
+<!-- If your change affects the UI, attach a screenshot or short recording. -->
+
+## Checklist
+
+- [ ] My branch is based on `develop`
+- [ ] I have updated documentation (README/CHANGELOG) where appropriate
+- [ ] My commits follow the project's [contributing guidelines](../CONTRIBUTING.md)

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,9 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Environment variables (never commit API keys)
+.env
+.env.local
+.env.*.local
+*.env


### PR DESCRIPTION
## Summary

Adds the GitHub repo infrastructure that external contributors expect.

- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured form (macOS/Xcode versions, repro steps, logs)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem / solution / alternatives
- `.github/pull_request_template.md` — type-of-change + testing checklist
- `.github/CODEOWNERS` — auto-request review from @krivoblotsky
- `.gitignore` — ignore `.env*` files so an OpenAI key can never be committed by accident

## Type of Change

- [x] CI / tooling

## Test plan

- [ ] Open a draft issue and confirm the bug-report and feature-request forms render
- [ ] Open a draft PR and confirm the PR template appears
- [ ] Confirm @krivoblotsky is auto-requested as reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)