### PR TITLE
fix: handle missing API key gracefully and surface errors in UI

### DIFF
--- a/Echo/Sources/Accessibility/AccessibleApplication.swift
+++ b/Echo/Sources/Accessibility/AccessibleApplication.swift
@@ -34,18 +34,10 @@ final class AccessbilableApplication: NSObject {
 
 final class Accessibility {
     
-    func requestAccess() {
-        // Specify a dialog alert text
+    @discardableResult
+    func requestAccess() -> Bool {
         let options: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as NSString: true]
-        
-        // Ask for permission
-        let accessEnabled = AXIsProcessTrustedWithOptions(options)
-        
-        if accessEnabled == true {
-            print("access granted")
-        } else {
-            print("access denied")
-        }
+        return AXIsProcessTrustedWithOptions(options)
     }
     
     func searchItem(from element: AXUIElement, criteria: (AccessibilityItem) -> Bool) -> [AccessibilityItem] {

--- a/Echo/Sources/Model/Agent.swift
+++ b/Echo/Sources/Model/Agent.swift
@@ -14,7 +14,12 @@ final class Agent {
         case emptyResult
     }
     
-    private let openAI = OpenAI(apiToken: ProcessInfo.processInfo.environment["OPEN_AI"]!)
+    private let openAI: OpenAI = {
+        guard let token = ProcessInfo.processInfo.environment["OPEN_AI"], !token.isEmpty else {
+            fatalError("OPEN_AI environment variable is not set. See README.md for setup instructions.")
+        }
+        return OpenAI(apiToken: token)
+    }()
     private let systemMessage = "You are an assistant that performs text and code operations. Return only the result, without any additional explanations. Do not add language identifiers."
     
     func query(inputString: String, prompt: String, reply: @escaping ((Result<String, Error>) -> Void)) {

--- a/Echo/Sources/Model/FrontmostApplication.swift
+++ b/Echo/Sources/Model/FrontmostApplication.swift
@@ -22,7 +22,6 @@ final class FrontmostApplication: NSObject {
             queue: .main
         ) { notification in
             if let userInfo = notification.userInfo, let app = userInfo[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication {
-                print("Frontmost application changed to: \(app.localizedName ?? "Unknown")")
                 onChange?(Application(runningApplication: app))
             }
         }

--- a/Echo/Sources/Screens/ViewController.swift
+++ b/Echo/Sources/Screens/ViewController.swift
@@ -71,26 +71,28 @@ private extension ViewController {
     
     func start(_ prompt: String) {
         guard let currentApplication = self.currentApplication else {
-            print("No application")
+            self.store.add(message: .textAnswer("No frontmost application detected."))
             return
         }
-        
+
         let accessbilableApplication = AccessbilableApplication(application: currentApplication)
         guard let editor = accessbilableApplication.fetchEditor() else {
-            print("No editor")
+            self.store.add(message: .textAnswer("No editable text area found in the frontmost application."))
             return
         }
-        
+
         self.store.add(message: .thinking("No problem. Updating..."))
-        self.agent.query(inputString: editor.value, prompt: prompt) { result in
+        self.agent.query(inputString: editor.value, prompt: prompt) { [weak self] result in
             switch result {
             case .success(let response):
                 editor.updateValue(response)
                 DispatchQueue.main.async {
-                    self.store.add(message: .textAnswer("Done!"))
+                    self?.store.add(message: .textAnswer("Done!"))
                 }
             case .failure(let error):
-                print(error)
+                DispatchQueue.main.async {
+                    self?.store.add(message: .textAnswer("Request failed: \(error.localizedDescription)"))
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Removes the cryptic crash when `OPEN_AI` is not set and turns the silent debug prints into user-visible chat messages.

### Fix: hard crash on missing API key

`Agent.swift` previously force-unwrapped `ProcessInfo.processInfo.environment[\"OPEN_AI\"]!`, so launching without the env var would crash with a useless \"unexpectedly found nil\" stack trace. Replaced with an init-time guard whose `fatalError` message points at the README:

```swift
private let openAI: OpenAI = {
    guard let token = ProcessInfo.processInfo.environment[\"OPEN_AI\"], !token.isEmpty else {
        fatalError(\"OPEN_AI environment variable is not set. See README.md for setup instructions.\")
    }
    return OpenAI(apiToken: token)
}()
```

### Cleanup: remove debug `print()` calls

- `ViewController.swift` — \"No application\", \"No editor\", and `print(error)` paths now post a chat message the user can actually see (\"No frontmost application detected.\", \"No editable text area found…\", \"Request failed: \(error.localizedDescription)\").
- `FrontmostApplication.swift` — drop the per-app-switch debug print.
- `AccessibleApplication.swift` — `requestAccess()` returns `Bool` instead of printing; callers can decide what to do.
- Agent reply closure now captures `self` weakly to avoid a retain cycle.

## Type of Change

- [x] Bug fix
- [x] Refactor / cleanup

## Test plan

- [ ] Launch without `OPEN_AI` set → confirm the `fatalError` message references the README
- [ ] Launch with `OPEN_AI` set → confirm app starts normally
- [ ] Trigger \"no editor\" path (focus an app with no AXTextArea, hit Send) → user-facing message appears in chat
- [ ] Trigger an OpenAI failure (e.g. invalid key) → error message appears in chat
- [ ] Console.app no longer shows \"Frontmost application changed to:\" / \"access granted\" / \"access denied\" spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)