### PR TITLE
chore: add SwiftLint config, build CI, unpin Xcode in CodeQL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Build
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project Echo.xcodeproj \
+            -scheme Echo \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcbeautify

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,8 +32,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Switch to Xcode 16.1
-      run: sudo xcode-select -s /Applications/Xcode_16.1.app
+    - name: Select latest stable Xcode
+      if: matrix.language == 'swift'
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
     
     - name: Initialize CodeQL
       uses: github/codeql-action/init@main

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,27 @@
+disabled_rules:
+  - trailing_whitespace
+  - todo
+
+opt_in_rules:
+  - empty_count
+  - explicit_init
+  - first_where
+  - sorted_first_last
+  - contains_over_first_not_nil
+  - last_where
+
+line_length:
+  warning: 140
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+
+identifier_name:
+  excluded:
+    - id
+    - to
+
+excluded:
+  - Echo.xcodeproj
+  - .build
+  - DerivedData


### PR DESCRIPTION
## Summary

Brings the project up to a contributor-friendly tooling baseline.

- **`.swiftlint.yml`** — pragmatic ruleset: line length 140 (200 error), opt-in best-practice rules (`empty_count`, `explicit_init`, `first_where`, `last_where`, `contains_over_first_not_nil`, `sorted_first_last`), exclude Xcode build artefacts.
- **`.github/workflows/build.yml`** — new workflow that builds the Xcode project on every push/PR to `develop` and `main`. Uses `maxim-lobanov/setup-xcode@v1` with `latest-stable` and `xcbeautify` for clean logs.
- **`.github/workflows/codeql.yml`** — replace the hardcoded `sudo xcode-select -s /Applications/Xcode_16.1.app` step with the same `setup-xcode@v1` action so the workflow doesn't break the next time the GitHub runner image moves on.

## Type of Change

- [x] CI / tooling

## Test plan

- [ ] CI Build workflow runs and succeeds against this PR
- [ ] CodeQL workflow runs against this PR with the new Xcode selector
- [ ] Run `swiftlint lint` locally and confirm no errors on the existing source tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)