### PR TITLE
chore: README badges, Dependabot, slim .gitignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "swift"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,70 +1,24 @@
-# Xcode
-#
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
-## User settings
-xcuserdata/
-
-## Obj-C/Swift specific
-*.hmap
-
-## App packaging
-*.ipa
-*.dSYM.zip
-*.dSYM
-
-xcuserdata/
-xcshareddata/
-
+# macOS
 .DS_Store
 
-## Playgrounds
-timeline.xctimeline
-playground.xcworkspace
+# Xcode user data
+xcuserdata/
 
-# Swift Package Manager
-#
-# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
-# *.xcodeproj
-#
-# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
-# hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
-
+# Build artefacts
+*.hmap
+*.ipa
+*.dSYM
+*.dSYM.zip
+DerivedData/
+build/
 .build/
 
-# CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# Pods/
-#
-# Add this line if you want to avoid checking in source code from the Xcode workspace
-# *.xcworkspace
+# Swift Package Manager
+.swiftpm/
 
-# Carthage
-#
-# Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
-
-Carthage/Build/
-
-# fastlane
-#
-# It is recommended to not store the screenshots in the git repo.
-# Instead, use fastlane to re-generate the screenshots whenever they are needed.
-# For more information about the recommended setup visit:
-# https://docs.fastlane.tools/best-practices/source-control/#source-control
-
-fastlane/report.xml
-fastlane/Preview.html
-fastlane/screenshots/**/*.png
-fastlane/test_output
+# Playgrounds
+timeline.xctimeline
+playground.xcworkspace
 
 # Environment variables (never commit API keys)
 .env

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ![EchoIcon-256](https://github.com/user-attachments/assets/5ce1e09e-8413-48cb-a626-99b45dd18717)
 
+[![Build](https://github.com/MacPaw/project-echo/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/MacPaw/project-echo/actions/workflows/build.yml)
+[![CodeQL](https://github.com/MacPaw/project-echo/actions/workflows/codeql.yml/badge.svg?branch=develop)](https://github.com/MacPaw/project-echo/actions/workflows/codeql.yml)
+[![Swift 5.9+](https://img.shields.io/badge/Swift-5.9%2B-orange.svg)](https://swift.org)
+[![Platform](https://img.shields.io/badge/platform-macOS%2014%2B-blue.svg)](https://www.apple.com/macos)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 **Echo** is a macOS application that demonstrates how to interact with macOS applications using Accessibility and [OpenAI](https://openai.com) APIs. It allows users to send prompts to the frontmost application and receive responses, showcasing a functional chat-like interface.
 
 <img width="1800" alt="Screenshot 2024-11-18 at 2 58 45 PM" src="https://github.com/user-attachments/assets/b7d2a457-d4c6-430b-8fae-c3364ea4c7af">


### PR DESCRIPTION
## Summary

Round-2 polish — small visible signals that the project is actively maintained.

- **README badges**: Build, CodeQL, Swift, platform, license. Linked to the actual workflows so they go red when CI breaks.
- **Dependabot** (`.github/dependabot.yml`): weekly checks for the OpenAI Swift SDK and GitHub Actions, capped at 5 open PRs each, with `chore(deps)` / `chore(ci)` commit prefixes.
- **`.gitignore` cleanup**: removed CocoaPods, Carthage, and fastlane sections (project is SPM-only and does not use any of them). Kept only the patterns this project actually needs plus the `.env*` guard from PR #4.

## Type of Change

- [x] Documentation
- [x] CI / tooling

## Test plan

- [ ] Confirm README badges render correctly on develop after merge
- [ ] Confirm Dependabot lists the workflow under Insights > Dependency graph > Dependabot
- [ ] `git status` on a fresh clone is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)