### PR TITLE
fix: rename AccessbilableApplication, use system role, match AXTextField

### DIFF
--- a/Echo/Sources/Accessibility/AccessibleApplication.swift
+++ b/Echo/Sources/Accessibility/AccessibleApplication.swift
@@ -9,7 +9,7 @@ import Foundation
 import Accessibility
 import ApplicationServices
 
-final class AccessbilableApplication: NSObject {
+final class AccessibleApplication: NSObject {
     
     private let accessibility = Accessibility()
     private let application: Application
@@ -18,16 +18,15 @@ final class AccessbilableApplication: NSObject {
         self.application = application
     }
     
+    private static let editableRoles: Set<String> = ["AXTextArea", "AXTextField"]
+
     func fetchEditor() -> AccessibilityItem? {
         accessibility.requestAccess()
-        
+
         let app: AXUIElement = .from(pid: application.pid)
         let items = accessibility.searchItem(from: app, criteria: {
-            if $0.role == "AXTextArea" {
-                return true//$0.isFocused
-            }
-            return false
-        }).filter { $0.value.isEmpty == false && $0.value.replacingOccurrences(of: " ", with: "").isEmpty == false }
+            Self.editableRoles.contains($0.role)
+        }).filter { !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
         return items.first
     }
 }

--- a/Echo/Sources/Model/Agent.swift
+++ b/Echo/Sources/Model/Agent.swift
@@ -25,7 +25,7 @@ final class Agent {
     func query(inputString: String, prompt: String, reply: @escaping ((Result<String, Error>) -> Void)) {
         let input = "\(inputString)\n\n---------\n\n\(prompt)"
         openAI.chats(query: .init(messages: [
-            .assistant(.init(content: systemMessage)),
+            .system(.init(content: systemMessage)),
             .user(.init(content: .init(string: input)))
         ], model: .gpt4_o)) { result in
             switch result {

--- a/Echo/Sources/Screens/ViewController.swift
+++ b/Echo/Sources/Screens/ViewController.swift
@@ -75,8 +75,8 @@ private extension ViewController {
             return
         }
 
-        let accessbilableApplication = AccessbilableApplication(application: currentApplication)
-        guard let editor = accessbilableApplication.fetchEditor() else {
+        let accessibleApplication = AccessibleApplication(application: currentApplication)
+        guard let editor = accessibleApplication.fetchEditor() else {
             self.store.add(message: .textAnswer("No editable text area found in the frontmost application."))
             return
         }

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Echo requires macOS Accessibility permissions and will prompt you automatically 
 **App crashes immediately on launch**
 The `OPEN_AI` environment variable is not set. Follow the [Development Setup](#development-setup) steps above to configure it in your Xcode scheme.
 
-**Echo does not detect the frontmost window / "No editor" in the log**
-The target application must expose an `AXTextArea` element. This works in most native text editors (Xcode, TextMate, BBEdit). Browser address bars and some web text areas may not be accessible via the Accessibility API.
+**Echo does not detect the frontmost window / "No editor" message**
+The target application must expose an `AXTextArea` or `AXTextField` element. This works in most native text editors (Xcode, TextMate, BBEdit) and many text fields. Browser address bars and some web text areas may not be accessible via the Accessibility API.
 
 **Accessibility permission is denied**
 Open **System Settings > Privacy & Security > Accessibility** and verify that Echo is listed and toggled on. Re-building from Xcode may require re-granting the permission.
@@ -98,7 +98,7 @@ Verify your API key is valid and has GPT-4o access. Check your [OpenAI usage das
 - **`FrontmostApplication`**:
   Observes and detects the currently active macOS application.
 
-- **`AccessbilableApplication`**:
+- **`AccessibleApplication`**:
   Provides Accessibility API integration to fetch and update content in the frontmost application.
 
 ### View Hierarchy


### PR DESCRIPTION
## Summary

Three small correctness fixes that an external reader would otherwise spot in the first 60 seconds.

### 1. Rename `AccessbilableApplication` → `AccessibleApplication`
The file was already called `AccessibleApplication.swift`, but the type inside was misspelled. Renamed the class and updated the one call site in `ViewController` plus the reference in the README.

### 2. Agent: use `.system` role for the system prompt
Before:
\`\`\`swift
.assistant(.init(content: systemMessage)),
.user(.init(content: .init(string: input)))
\`\`\`

`.assistant` tells GPT-4o that the system prompt is a prior model turn, which changes how it weighs the instruction (and is just wrong semantically). Switched to `.system(.init(content:))` — verified the case exists in the MacPaw OpenAI SDK 0.3.0 (`ChatQuery.swift:113`).

### 3. Match `AXTextField` in addition to `AXTextArea`
`fetchEditor()` now matches both roles via a `Set<String>`. This lets Echo target single-line text inputs — search bars, address fields, comment boxes — not only multi-line editors. Also tightened the \"is this just whitespace?\" filter from a hand-rolled space-replace to `trimmingCharacters(in: .whitespacesAndNewlines)`.

## Type of Change

- [x] Bug fix
- [x] Refactor / cleanup

## Test plan

- [ ] Build succeeds (the new Build workflow from PR #6 will catch this)
- [ ] App launches and processes a prompt against an `AXTextArea` (Xcode / TextMate)
- [ ] App now processes a prompt against an `AXTextField` (e.g. Notes search field)
- [ ] Verify the model responds appropriately to the system prompt (\"return only the result, no language identifiers\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)